### PR TITLE
Download images for filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.png
 data/
 purity-vision-filter
+*~

--- a/build/init.sql
+++ b/build/init.sql
@@ -15,11 +15,11 @@ ALTER TABLE public.users
 
 CREATE TABLE public.images
 (
-    img_uri_hash text NOT NULL,
+    img_hash text NOT NULL,
     error text,
     pass boolean NOT NULL default false,
     date_added timestamp NOT NULL default CURRENT_TIMESTAMP,
-    PRIMARY KEY (img_uri_hash)
+    PRIMARY KEY (img_hash)
 );
 
 ALTER TABLE public.images

--- a/build/init.sql
+++ b/build/init.sql
@@ -15,11 +15,12 @@ ALTER TABLE public.users
 
 CREATE TABLE public.images
 (
-    img_hash text NOT NULL,
+    hash text NOT NULL, -- Hash of the b64 content encoding.
+    uri text NOT NULL,
     error text,
     pass boolean NOT NULL default false,
     date_added timestamp NOT NULL default CURRENT_TIMESTAMP,
-    PRIMARY KEY (img_hash)
+    PRIMARY KEY (hash)
 );
 
 ALTER TABLE public.images

--- a/src/images/db.go
+++ b/src/images/db.go
@@ -29,13 +29,13 @@ func FindByURI(conn *pg.DB, imgURIList []string) ([]Image, error) {
 		uriHashList = append(uriHashList, utils.Hash(uri))
 	}
 
-	conn.Model(&imgList).Where("img_uri_hash IN (?)", pg.In(uriHashList)).Select()
+	conn.Model(&imgList).Where("uri IN (?)", pg.In(imgURIList)).Select()
 
 	for _, img := range imgList {
-		logger.Debug().Msgf("Found cached image: %s...", img.ImgURIHash[:8])
+		logger.Debug().Msgf("Found cached image: %s...", img.URI)
 	}
 
-	logger.Debug().Msgf("Found %d/%d cached images", len(imgList), len(imgURIList))
+	logger.Debug().Msgf("Cached %d/%d images", len(imgList), len(imgURIList))
 
 	return imgList, nil
 }
@@ -46,17 +46,16 @@ func Insert(conn *pg.DB, image *Image) error {
 	if err != nil {
 		return err
 	}
-	logger.Debug().Msgf("inserted image: %s", image.ImgURIHash)
+	logger.Debug().Msgf("inserted image: %s", image.URI)
 
 	return nil
 }
 
 // DeleteByURI deletes the images with matching URI.
 func DeleteByURI(conn *pg.DB, uri string) error {
-	hash := utils.Hash(uri)
-	img := Image{ImgURIHash: hash}
+	img := Image{URI: uri}
 
-	if _, err := conn.Model(&img).Where("img_uri_hash = ?", hash).Delete(); err != nil {
+	if _, err := conn.Model(&img).Where("uri = ?", uri).Delete(); err != nil {
 		return err
 	}
 

--- a/src/images/images.go
+++ b/src/images/images.go
@@ -3,20 +3,20 @@ package images
 import (
 	"database/sql"
 	"net/url"
-	"purity-vision-filter/src/utils"
 	"time"
 )
 
 // Image represents a pass/fail status of a previously queried img URI.
 type Image struct {
-	ImgURIHash string         `json:"img_uri_hash"`
-	Error      sql.NullString `json:"error"`
-	Pass       bool           `json:"pass"`
-	DateAdded  time.Time      `json:"dateAdded"`
+	Hash      string         `json:"hash"`
+	URI       string         `json:"uri"`
+	Error     sql.NullString `json:"error"`
+	Pass      bool           `json:"pass"`
+	DateAdded time.Time      `json:"dateAdded"`
 }
 
 // NewImage returns a new Image instance (wow).
-func NewImage(uri string, err error, pass bool, dateAdded time.Time) (*Image, error) {
+func NewImage(hash string, uri string, err error, pass bool, dateAdded time.Time) (*Image, error) {
 	var sqlErr sql.NullString
 	var validErr bool
 
@@ -32,9 +32,10 @@ func NewImage(uri string, err error, pass bool, dateAdded time.Time) (*Image, er
 	sqlErr = sql.NullString{String: err.Error(), Valid: validErr}
 
 	return &Image{
-		ImgURIHash: utils.Hash(uri),
-		Error:      sqlErr,
-		Pass:       pass,
-		DateAdded:  dateAdded,
+		Hash:      hash,
+		URI:       uri,
+		Error:     sqlErr,
+		Pass:      pass,
+		DateAdded: dateAdded,
 	}, nil
 }

--- a/src/images/images_test.go
+++ b/src/images/images_test.go
@@ -37,18 +37,20 @@ func TestMain(m *testing.M) {
 func TestNewImage(t *testing.T) {
 	uri := "https://google.com"
 	time := time.Now()
+	fakeHash := utils.Hash("some string")
 	expected := Image{
-		utils.Hash(uri),
+		fakeHash,
+		uri,
 		sql.NullString{},
 		true,
 		time,
 	}
-	img, err := NewImage(uri, fmt.Errorf(""), true, time)
+	img, err := NewImage(fakeHash, uri, fmt.Errorf(""), true, time)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if (expected.ImgURIHash != img.ImgURIHash) ||
+	if (expected.Hash != img.Hash) ||
 		(expected.Error != img.Error) ||
 		(expected.Pass != img.Pass) ||
 		(expected.DateAdded != img.DateAdded) {
@@ -58,7 +60,8 @@ func TestNewImage(t *testing.T) {
 
 func TestInsertImage(t *testing.T) {
 	for _, uri := range imgURIList {
-		img, err := NewImage(uri, fmt.Errorf(""), true, time.Now())
+		fakeHash := utils.Hash(uri)
+		img, err := NewImage(fakeHash, uri, fmt.Errorf(""), true, time.Now())
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -42,9 +42,7 @@ type ImgFilterRes struct {
 
 // BatchImgFilterRes represents a list of pass/fail statuses and any errors for each
 // supplied image URI.
-type BatchImgFilterRes struct {
-	ImgFilterResList []ImgFilterRes `json:"imgFilterResList"`
-}
+type BatchImgFilterRes []ImgFilterRes
 
 // ErrorRes is a JSON response containing an error message from the API.
 type ErrorRes struct {

--- a/src/server/server_test.go
+++ b/src/server/server_test.go
@@ -64,11 +64,9 @@ func TestBatchImgFilterHandler(t *testing.T) {
 		t.Error("Web server should have returned a 200")
 	}
 	var fRes BatchImgFilterRes
-	fRes = BatchImgFilterRes{
-		ImgFilterResList: []ImgFilterRes{},
-	}
+	fRes = []ImgFilterRes{}
 	json.Unmarshal(res.Body.Bytes(), &fRes)
-	if len(fRes.ImgFilterResList) != 1 || fRes.ImgFilterResList[0].Pass != true {
+	if len(fRes) != 1 || fRes[0].Pass != true {
 		t.Error("Handler didn't return the right results")
 	}
 

--- a/src/utils/b64.go
+++ b/src/utils/b64.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	"bufio"
+	"encoding/base64"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+func Base64EncodeF(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+
+	r := bufio.NewReader(f)
+	content, _ := ioutil.ReadAll(r)
+	return base64.StdEncoding.EncodeToString(content), nil
+}
+
+func Base64EncodeR(r io.Reader) (io.Reader, error) {
+	content, _ := ioutil.ReadAll(r)
+	return strings.NewReader(base64.StdEncoding.EncodeToString(content)), nil
+}

--- a/src/utils/download.go
+++ b/src/utils/download.go
@@ -1,0 +1,33 @@
+package utils
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+func Download(uri string) (string, error) {
+	if _, err := url.ParseRequestURI(uri); err != nil {
+		return "", err
+	}
+
+	// Create temp file for download.
+	f, err := ioutil.TempFile("", "purity-img")
+	if err != nil {
+		return "", err
+	}
+
+	res, err := http.Get(uri)
+	if err != nil {
+		return "", err
+	}
+
+	defer res.Body.Close()
+
+	_, err = io.Copy(f, res.Body)
+	if err != nil {
+		return "", err
+	}
+	return f.Name(), nil
+}

--- a/src/vision/google_vision.go
+++ b/src/vision/google_vision.go
@@ -11,8 +11,8 @@ import (
 
 // GetImgAnnotations sends a batch request to the Google Vision API to retrieve tags and likelihood values
 // for the URI list in the batch request.
-func GetImgAnnotations(imgURIs []string) (*pb.BatchAnnotateImagesResponse, error) {
-	if len(imgURIs) == 0 {
+func GetImgAnnotations(contentURIMap map[string]string) (*pb.BatchAnnotateImagesResponse, error) {
+	if len(contentURIMap) == 0 {
 		return nil, nil
 	}
 
@@ -27,8 +27,17 @@ func GetImgAnnotations(imgURIs []string) (*pb.BatchAnnotateImagesResponse, error
 	var annotateReqs []*pb.AnnotateImageRequest
 
 	// Loop over the files and create annotate requests.
-	for _, uri := range imgURIs {
-		image := vision.NewImageFromURI(uri)
+	for _, path := range contentURIMap {
+		f, err := os.Open(path)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+
+		image, err := vision.NewImageFromReader(f)
+		if err != nil {
+			return nil, err
+		}
 		annotateReqs = append(annotateReqs, &pb.AnnotateImageRequest{
 			Image: image,
 			Features: []*pb.Feature{


### PR DESCRIPTION
Close #42 

Base 64 encoding images was not necessary for feeding the image data to the Vision API.